### PR TITLE
Protobuf model, names for operations in layers

### DIFF
--- a/makiflow/base/maki_entities/maki_layer.py
+++ b/makiflow/base/maki_entities/maki_layer.py
@@ -23,7 +23,9 @@ class MakiRestorable(ABC):
     PARAMS = 'params'
     FIELD_TYPE = 'type'
     NAME = 'name'
-    OP = 'operations'
+
+    TRAINING_PREFIX = '/training'
+    TEST_PREFIX = '/inference'
 
     @staticmethod
     def build(params: dict):

--- a/makiflow/base/maki_entities/maki_layer.py
+++ b/makiflow/base/maki_entities/maki_layer.py
@@ -24,8 +24,8 @@ class MakiRestorable(ABC):
     FIELD_TYPE = 'type'
     NAME = 'name'
 
-    TRAINING_MODE = 'TrainingGraph/'
-    INFERENCE_MODE = 'InferenceGraph/'
+    TRAINING_MODE = 'TrainingGraph'
+    INFERENCE_MODE = 'InferenceGraph'
 
     @staticmethod
     def build(params: dict):

--- a/makiflow/base/maki_entities/maki_layer.py
+++ b/makiflow/base/maki_entities/maki_layer.py
@@ -24,8 +24,8 @@ class MakiRestorable(ABC):
     FIELD_TYPE = 'type'
     NAME = 'name'
 
-    TRAINING_PREFIX = '/training'
-    TEST_PREFIX = '/inference'
+    TRAINING_PREFIX = '_training'
+    TEST_PREFIX = '_inference'
 
     @staticmethod
     def build(params: dict):

--- a/makiflow/base/maki_entities/maki_layer.py
+++ b/makiflow/base/maki_entities/maki_layer.py
@@ -24,8 +24,8 @@ class MakiRestorable(ABC):
     FIELD_TYPE = 'type'
     NAME = 'name'
 
-    TRAINING_PREFIX = 'TrainingGraph/'
-    TEST_PREFIX = 'InferenceGraph/'
+    TRAINING_MODE = 'TrainingGraph/'
+    INFERENCE_MODE = 'InferenceGraph/'
 
     @staticmethod
     def build(params: dict):

--- a/makiflow/base/maki_entities/maki_layer.py
+++ b/makiflow/base/maki_entities/maki_layer.py
@@ -24,8 +24,8 @@ class MakiRestorable(ABC):
     FIELD_TYPE = 'type'
     NAME = 'name'
 
-    TRAINING_PREFIX = '_training'
-    TEST_PREFIX = '_inference'
+    TRAINING_PREFIX = 'InferenceGraph/'
+    TEST_PREFIX = 'InferenceGraph/'
 
     @staticmethod
     def build(params: dict):

--- a/makiflow/base/maki_entities/maki_layer.py
+++ b/makiflow/base/maki_entities/maki_layer.py
@@ -23,6 +23,7 @@ class MakiRestorable(ABC):
     PARAMS = 'params'
     FIELD_TYPE = 'type'
     NAME = 'name'
+    OP = 'operations'
 
     @staticmethod
     def build(params: dict):

--- a/makiflow/base/maki_entities/maki_layer.py
+++ b/makiflow/base/maki_entities/maki_layer.py
@@ -24,7 +24,7 @@ class MakiRestorable(ABC):
     FIELD_TYPE = 'type'
     NAME = 'name'
 
-    TRAINING_PREFIX = 'InferenceGraph/'
+    TRAINING_PREFIX = 'TrainingGraph/'
     TEST_PREFIX = 'InferenceGraph/'
 
     @staticmethod

--- a/makiflow/base/maki_entities/maki_model.py
+++ b/makiflow/base/maki_entities/maki_model.py
@@ -47,6 +47,9 @@ class MakiModel(ABC):
         for maki_tensor in self._inputs:
             self._input_data_tensors += [maki_tensor.get_data_tensor()]
 
+        # For training
+        self._training_outputs = []
+
         self._collect_params()
 
     def _collect_params(self):
@@ -131,6 +134,9 @@ class MakiModel(ABC):
         output_names = [
             single_output.get_data_tensor().name.split(':')[0]
             for single_output in self._outputs
+        ] + [
+            single_output.name.split(':')[0]
+            for single_output in self._training_outputs
         ]
 
         frozen_graph = None

--- a/makiflow/base/maki_entities/maki_tensor.py
+++ b/makiflow/base/maki_entities/maki_tensor.py
@@ -23,6 +23,9 @@ class MakiTensor:
     PARENT_TENSOR_NAMES = 'parent_tensor_names'
     PARENT_LAYER_INFO = 'parent_layer_info'
 
+    OBJ2STR = "MakiTensor(name={}, shape={}, dtype={})"
+    OBJ2REPR = "<mf.base.MakiTensor 'name={}' shape={} dtype={}>"
+
     def __init__(self, data_tensor: tf.Tensor, parent_layer, parent_tensor_names: list,
                  previous_tensors: dict, name=None, index=None):
         """
@@ -100,16 +103,16 @@ class MakiTensor:
     def __str__(self):
         name = self._name
         shape = self.get_shape()
-        dtype = self._data_tensor._dtype.name
+        dtype = self._data_tensor.dtype.name
 
-        return f"MakiTensor(name={name}, shape={shape}, dtype={dtype})"
+        return MakiTensor.OBJ2STR.format(name, shape, dtype)
 
     def __repr__(self):
         name = self._name
         shape = self.get_shape()
-        dtype = self._data_tensor._dtype.name
+        dtype = self._data_tensor.dtype.name
 
-        return f"<mf.base.MakiTensor 'name={name}' shape={shape} dtype={dtype}>"
+        return MakiTensor.OBJ2REPR.format(name, shape, dtype)
 
     def get_name(self):
         return self._name

--- a/makiflow/base/maki_entities/maki_trainer.py
+++ b/makiflow/base/maki_entities/maki_trainer.py
@@ -235,10 +235,13 @@ class MakiTrainer(MakiModel, ABC):
                         takes += [create_tensor(elem)]
 
                     if layer.get_name() in self._trainable_layers:
-                        X = layer._training_forward(takes[0] if len(takes) == 1 else takes)
+                        X = layer._training_forward(
+                            takes[0] if len(takes) == 1 else takes
+                        )
                     else:
-                        X = layer._forward(takes[0] if len(takes) == 1 else takes,
-                                           MakiRestorable.TRAINING_PREFIX
+                        X = layer._forward(
+                            takes[0] if len(takes) == 1 else takes,
+                            MakiRestorable.TRAINING_MODE
                         )
                     output_tensors[layer.get_name()] = X
                     # Check if the layer returns several tensors

--- a/makiflow/base/maki_entities/maki_trainer.py
+++ b/makiflow/base/maki_entities/maki_trainer.py
@@ -249,6 +249,5 @@ class MakiTrainer(MakiModel, ABC):
             else:
                 return output_tensors[maki_tensor.get_name()]
 
-        self._training_outputs = []
         for output in self._outputs:
             self._training_outputs += [create_tensor(output)]

--- a/makiflow/base/maki_entities/maki_trainer.py
+++ b/makiflow/base/maki_entities/maki_trainer.py
@@ -17,6 +17,7 @@
 
 from abc import ABC
 from makiflow.base.maki_entities.maki_model import MakiModel
+from makiflow.base.maki_entities.maki_layer import MakiRestorable
 from .maki_tensor import MakiTensor
 import tensorflow as tf
 from copy import copy
@@ -236,7 +237,9 @@ class MakiTrainer(MakiModel, ABC):
                     if layer.get_name() in self._trainable_layers:
                         X = layer._training_forward(takes[0] if len(takes) == 1 else takes)
                     else:
-                        X = layer._forward(takes[0] if len(takes) == 1 else takes)
+                        X = layer._forward(takes[0] if len(takes) == 1 else takes,
+                                           MakiRestorable.TRAINING_PREFIX
+                        )
                     output_tensors[layer.get_name()] = X
                     # Check if the layer returns several tensors
                     index = maki_tensor.get_index()

--- a/makiflow/generators/pipeline/tfr/tfr_pathgenerator.py
+++ b/makiflow/generators/pipeline/tfr/tfr_pathgenerator.py
@@ -42,7 +42,7 @@ class CycleGenerator(TFRPathGenerator):
         tfrecords : list
             List of paths to the tfrecords.
         """
-        self._tfrecords = tfrecords
+        self._tfrecords = shuffle(tfrecords)
 
     def next_element(self):
         n_records = len(self._tfrecords)

--- a/makiflow/generators/pipeline/tfr/tfr_pathgenerator.py
+++ b/makiflow/generators/pipeline/tfr/tfr_pathgenerator.py
@@ -32,7 +32,7 @@ class TFRPathGenerator(PathGenerator):
 
 
 class CycleGenerator(TFRPathGenerator):
-    def __init__(self, tfrecords):
+    def __init__(self, tfrecords, init_shuffle=False):
         """
         Generator for the tfrecord pipeline which gives next tfrecord in a cyclic order.
         After each cycle data is randomly shuffled.
@@ -41,8 +41,13 @@ class CycleGenerator(TFRPathGenerator):
         ----------
         tfrecords : list
             List of paths to the tfrecords.
+        init_shuffle : bool
+            If True, shuffle of tfrecords will be performed before the cycle begins
         """
-        self._tfrecords = shuffle(tfrecords)
+        if init_shuffle:
+            self._tfrecords = shuffle(tfrecords)
+        else:
+            self._tfrecords = tfrecords
 
     def next_element(self):
         n_records = len(self._tfrecords)

--- a/makiflow/layers/neural_texture.py
+++ b/makiflow/layers/neural_texture.py
@@ -48,8 +48,8 @@ class SingleTextureLayer(SimpleForwardLayer):
                          named_params_dict=named_params_dict
         )
 
-    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
-        with tf.name_scope(type_graph_operation + super().get_name()):
+    def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
+        with tf.name_scope(computation_mode + super().get_name()):
             # Normalize the input UV map so that its coordinates are within [-1, 1] range.
             x = X * 2.0 - 1.0
             batch_size = x.get_shape().as_list()[0]
@@ -57,7 +57,7 @@ class SingleTextureLayer(SimpleForwardLayer):
             return grid_sample(expanded_texture, x)
 
     def _training_forward(self, X):
-        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
+        return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
 
     @staticmethod
     def build(params: dict):
@@ -114,16 +114,16 @@ class LaplacianPyramidTextureLayer(SimpleForwardLayer):
 
         super().__init__(name, params, named_params_dict)
 
-    def _forward(self, x, type_graph_operation=MakiRestorable.TEST_PREFIX):
-        with tf.name_scope(type_graph_operation + super().get_name()):
+    def _forward(self, x, computation_mode=MakiRestorable.INFERENCE_MODE):
+        with tf.name_scope(computation_mode + super().get_name()):
             # Normalize the input UV map so that its coordinates are within [-1, 1] range.
             y = []
             for d in range(self._depth):
-                y += [self._textures[d]._forward(x, type_graph_operation)]
+                y += [self._textures[d]._forward(x, computation_mode)]
             return tf.add_n(y)
 
     def _training_forward(self, x):
-        return self._forward(x, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
+        return self._forward(x, computation_mode=MakiRestorable.TRAINING_MODE)
 
     @staticmethod
     def build(params: dict):

--- a/makiflow/layers/neural_texture.py
+++ b/makiflow/layers/neural_texture.py
@@ -48,15 +48,16 @@ class SingleTextureLayer(SimpleForwardLayer):
                          named_params_dict=named_params_dict
         )
 
-    def _forward(self, x):
-        # Normalize the input UV map so that its coordinates are within [-1, 1] range.
-        x = x * 2.0 - 1.0
-        batch_size = x.get_shape().as_list()[0]
-        expanded_texture = tf.concat([self._texture] * batch_size, axis=0)
-        return grid_sample(expanded_texture, x)
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            # Normalize the input UV map so that its coordinates are within [-1, 1] range.
+            x = X * 2.0 - 1.0
+            batch_size = x.get_shape().as_list()[0]
+            expanded_texture = tf.concat([self._texture] * batch_size, axis=0)
+            return grid_sample(expanded_texture, x)
 
-    def _training_forward(self, x):
-        return self._forward(x)
+    def _training_forward(self, X):
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -113,16 +114,16 @@ class LaplacianPyramidTextureLayer(SimpleForwardLayer):
 
         super().__init__(name, params, named_params_dict)
 
-    # noinspection PyProtectedMember
-    def _forward(self, x):
-        # Normalize the input UV map so that its coordinates are within [-1, 1] range.
-        y = []
-        for d in range(self._depth):
-            y += [self._textures[d]._forward(x)]
-        return tf.add_n(y)
+    def _forward(self, x, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            # Normalize the input UV map so that its coordinates are within [-1, 1] range.
+            y = []
+            for d in range(self._depth):
+                y += [self._textures[d]._forward(x, type_graph_operation)]
+            return tf.add_n(y)
 
     def _training_forward(self, x):
-        return self._forward(x)
+        return self._forward(x, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):

--- a/makiflow/layers/neural_texture.py
+++ b/makiflow/layers/neural_texture.py
@@ -29,6 +29,8 @@ class SingleTextureLayer(SimpleForwardLayer):
     HEIGHT = 'HEIGHT'
     NUM_F = 'NUM_F'
 
+    TEXTURE_NAME = 'NTexture{}_{}_{}'
+
     def __init__(self, width, height, num_f, name, text_init=None):
         self._w = width
         self._h = height
@@ -36,7 +38,7 @@ class SingleTextureLayer(SimpleForwardLayer):
 
         if text_init is None:
             text_init = np.random.randn(1, height, width, num_f).astype(np.float32)
-        self._text_name = f'NTexture{width}_{height}_{name}'
+        self._text_name = SingleTextureLayer.TEXTURE_NAME.format(width, height, name)
         self._texture = tf.Variable(text_init, name=self._text_name)
         params = [self._texture]
         named_params_dict = {self._text_name: self._texture}

--- a/makiflow/layers/neural_texture.py
+++ b/makiflow/layers/neural_texture.py
@@ -49,12 +49,13 @@ class SingleTextureLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + super().get_name()):
-            # Normalize the input UV map so that its coordinates are within [-1, 1] range.
-            x = X * 2.0 - 1.0
-            batch_size = x.get_shape().as_list()[0]
-            expanded_texture = tf.concat([self._texture] * batch_size, axis=0)
-            return grid_sample(expanded_texture, x)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                # Normalize the input UV map so that its coordinates are within [-1, 1] range.
+                x = X * 2.0 - 1.0
+                batch_size = x.get_shape().as_list()[0]
+                expanded_texture = tf.concat([self._texture] * batch_size, axis=0)
+                return grid_sample(expanded_texture, x)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -115,12 +116,13 @@ class LaplacianPyramidTextureLayer(SimpleForwardLayer):
         super().__init__(name, params, named_params_dict)
 
     def _forward(self, x, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + super().get_name()):
-            # Normalize the input UV map so that its coordinates are within [-1, 1] range.
-            y = []
-            for d in range(self._depth):
-                y += [self._textures[d]._forward(x, computation_mode)]
-            return tf.add_n(y)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                # Normalize the input UV map so that its coordinates are within [-1, 1] range.
+                y = []
+                for d in range(self._depth):
+                    y += [self._textures[d]._forward(x, computation_mode)]
+                return tf.add_n(y)
 
     def _training_forward(self, x):
         return self._forward(x, computation_mode=MakiRestorable.TRAINING_MODE)

--- a/makiflow/layers/sf_layer.py
+++ b/makiflow/layers/sf_layer.py
@@ -38,6 +38,6 @@ class SimpleForwardLayer(MakiLayer):
         return maki_tensor
 
     @abstractmethod
-    def _forward(self, x):
+    def _forward(self, x, type_graph_operation):
         pass
 

--- a/makiflow/layers/trainable_layers.py
+++ b/makiflow/layers/trainable_layers.py
@@ -35,8 +35,8 @@ class ConvLayer(SimpleForwardLayer):
     USE_BIAS = 'use_bias'
     INIT_TYPE = 'init_type'
 
-    BIAS = '/bias'
-    ACTIVATION = '/activation'
+    BIAS = '_bias'
+    ACTIVATION = '_activation'
 
     NAME_BIAS = 'ConvBias_{}x{}_in{}_out{}_id_{}'
     NAME_CONV_W = 'ConvKernel_{}x{}_in{}_out{}_id_{}'
@@ -166,8 +166,8 @@ class UpConvLayer(SimpleForwardLayer):
     USE_BIAS = 'use_bias'
     INIT_TYPE = 'init_type'
 
-    BIAS = '/bias'
-    ACTIVATION = '/activation'
+    BIAS = '_bias'
+    ACTIVATION = '_activation'
 
     NAME_BIAS = 'UpConvBias_{}x{}_in{}_out{}_id_{}'
     NAME_CONV_W = 'UpConvKernel_{}x{}_out{}_in{}_id_{}'

--- a/makiflow/layers/trainable_layers.py
+++ b/makiflow/layers/trainable_layers.py
@@ -103,15 +103,16 @@ class ConvLayer(SimpleForwardLayer):
         )
 
     def _forward(self, x):
-        conv_out = tf.nn.conv2d(x, self.W,
-                                strides=[1, self.stride, self.stride, 1],
-                                padding=self.padding,
-                                name=self._name)
-        if self.use_bias:
-            conv_out = tf.nn.bias_add(conv_out, self.b, name=self._name + ConvLayer.BIAS)
-        if self.f is None:
-            return conv_out
-        return self.f(conv_out, name=self._name + ConvLayer.ACTIVATION)
+        with tf.name_scope(ConvLayer.TYPE):
+            conv_out = tf.nn.conv2d(x, self.W,
+                                    strides=[1, self.stride, self.stride, 1],
+                                    padding=self.padding,
+                                    name=self._name)
+            if self.use_bias:
+                conv_out = tf.nn.bias_add(conv_out, self.b, name=self._name + ConvLayer.BIAS)
+            if self.f is None:
+                return conv_out
+            return self.f(conv_out, name=self._name + ConvLayer.ACTIVATION)
 
     def _training_forward(self, X):
         return self._forward(X)
@@ -236,22 +237,23 @@ class UpConvLayer(SimpleForwardLayer):
         )
 
     def _forward(self, x):
-        out_shape = x.get_shape().as_list()
-        out_shape[1] *= self.size[0]
-        out_shape[2] *= self.size[1]
-        # out_f
-        out_shape[3] = self.shape[2]
-        conv_out = tf.nn.conv2d_transpose(
-            x, self.W,
-            output_shape=out_shape, strides=self.strides, padding=self.padding,
-            name=self._name
-        )
-        if self.use_bias:
-            conv_out = tf.nn.bias_add(conv_out, self.b, name=self._name + UpConvLayer.BIAS)
+        with tf.name_scope(UpConvLayer.TYPE):
+            out_shape = x.get_shape().as_list()
+            out_shape[1] *= self.size[0]
+            out_shape[2] *= self.size[1]
+            # out_f
+            out_shape[3] = self.shape[2]
+            conv_out = tf.nn.conv2d_transpose(
+                x, self.W,
+                output_shape=out_shape, strides=self.strides, padding=self.padding,
+                name=self._name
+            )
+            if self.use_bias:
+                conv_out = tf.nn.bias_add(conv_out, self.b, name=self._name + UpConvLayer.BIAS)
 
-        if self.f is None:
-            return conv_out
-        return self.f(conv_out, name=self._name + UpConvLayer.ACTIVATION)
+            if self.f is None:
+                return conv_out
+            return self.f(conv_out, name=self._name + UpConvLayer.ACTIVATION)
 
     def _training_forward(self, X):
         return self._forward(X)
@@ -1495,37 +1497,38 @@ class InstanceNormLayer(BatchNormBaseLayer):
         self._named_params_dict[self.name_var] = self.running_variance
 
     def _forward(self, X):
-        if self._track_running_stats:
-            return tf.nn.batch_normalization(
-                X,
-                self.running_mean,
-                self.running_variance,
-                self.beta,
-                self.gamma,
-                self.eps,
-                name=self._name
-            )
-        else:
-            # These if statements check if we do batchnorm for convolution or dense
-            if len(X.shape) == 4:
-                # conv
-                axes = [1, 2]
+        with tf.name_scope(InstanceNormLayer.TYPE):
+            if self._track_running_stats:
+                return tf.nn.batch_normalization(
+                    X,
+                    self.running_mean,
+                    self.running_variance,
+                    self.beta,
+                    self.gamma,
+                    self.eps,
+                    name=self._name
+                )
             else:
-                # dense
-                axes = [1]
+                # These if statements check if we do batchnorm for convolution or dense
+                if len(X.shape) == 4:
+                    # conv
+                    axes = [1, 2]
+                else:
+                    # dense
+                    axes = [1]
 
-            # Output shape [N, 1, 1, C] for Conv and [N, F] for Dense
-            batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
+                # Output shape [N, 1, 1, C] for Conv and [N, F] for Dense
+                batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
 
-            return tf.nn.batch_normalization(
-                X,
-                batch_mean,
-                batch_var,
-                self.beta,
-                self.gamma,
-                self.eps,
-                name=self._name
-            )
+                return tf.nn.batch_normalization(
+                    X,
+                    batch_mean,
+                    batch_var,
+                    self.beta,
+                    self.gamma,
+                    self.eps,
+                    name=self._name
+                )
 
     def _training_forward(self, X):
         if not self._track_running_stats:

--- a/makiflow/layers/trainable_layers.py
+++ b/makiflow/layers/trainable_layers.py
@@ -108,18 +108,19 @@ class ConvLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            conv_out = tf.nn.conv2d(
-                X, self.W,
-                strides=[1, self.stride, self.stride, 1],
-                padding=self.padding,
-                name=self.get_name()
-            )
-            if self.use_bias:
-                conv_out = tf.nn.bias_add(conv_out, self.b, name=self.get_name() + ConvLayer.BIAS)
-            if self.f is None:
-                return conv_out
-            return self.f(conv_out, name=self.get_name() + ConvLayer.ACTIVATION_PREFIX)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                conv_out = tf.nn.conv2d(
+                    X, self.W,
+                    strides=[1, self.stride, self.stride, 1],
+                    padding=self.padding,
+                    name=self.get_name()
+                )
+                if self.use_bias:
+                    conv_out = tf.nn.bias_add(conv_out, self.b, name=self.get_name() + ConvLayer.BIAS)
+                if self.f is None:
+                    return conv_out
+                return self.f(conv_out, name=self.get_name() + ConvLayer.ACTIVATION_PREFIX)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -249,23 +250,24 @@ class UpConvLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            out_shape = X.get_shape().as_list()
-            out_shape[1] *= self.size[0]
-            out_shape[2] *= self.size[1]
-            # out_f
-            out_shape[3] = self.shape[2]
-            conv_out = tf.nn.conv2d_transpose(
-                X, self.W,
-                output_shape=out_shape, strides=self.strides, padding=self.padding,
-                name=self.get_name()
-            )
-            if self.use_bias:
-                conv_out = tf.nn.bias_add(conv_out, self.b, name=self.get_name() + UpConvLayer.BIAS)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                out_shape = X.get_shape().as_list()
+                out_shape[1] *= self.size[0]
+                out_shape[2] *= self.size[1]
+                # out_f
+                out_shape[3] = self.shape[2]
+                conv_out = tf.nn.conv2d_transpose(
+                    X, self.W,
+                    output_shape=out_shape, strides=self.strides, padding=self.padding,
+                    name=self.get_name()
+                )
+                if self.use_bias:
+                    conv_out = tf.nn.bias_add(conv_out, self.b, name=self.get_name() + UpConvLayer.BIAS)
 
-            if self.f is None:
-                return conv_out
-            return self.f(conv_out, name=self.get_name() + UpConvLayer.ACTIVATION_PREFIX)
+                if self.f is None:
+                    return conv_out
+                return self.f(conv_out, name=self.get_name() + UpConvLayer.ACTIVATION_PREFIX)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -360,8 +362,9 @@ class BiasLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            return tf.nn.bias_add(X, self.b, self.get_name())
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                return tf.nn.bias_add(X, self.b, self.get_name())
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -469,20 +472,21 @@ class DepthWiseConvLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            conv_out = tf.nn.depthwise_conv2d(
-                input=X,
-                filter=self.W,
-                strides=[1, self.stride, self.stride, 1],
-                padding=self.padding,
-                rate=self.rate,
-                name=self.get_name()
-            )
-            if self.use_bias:
-                conv_out = tf.nn.bias_add(conv_out, self.b, name=self.get_name() + DepthWiseConvLayer.BIAS)
-            if self.f is None:
-                return conv_out
-            return self.f(conv_out, name=self.get_name() + DepthWiseConvLayer.ACTIVATION_PREFIX)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                conv_out = tf.nn.depthwise_conv2d(
+                    input=X,
+                    filter=self.W,
+                    strides=[1, self.stride, self.stride, 1],
+                    padding=self.padding,
+                    rate=self.rate,
+                    name=self.get_name()
+                )
+                if self.use_bias:
+                    conv_out = tf.nn.bias_add(conv_out, self.b, name=self.get_name() + DepthWiseConvLayer.BIAS)
+                if self.f is None:
+                    return conv_out
+                return self.f(conv_out, name=self.get_name() + DepthWiseConvLayer.ACTIVATION_PREFIX)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -624,20 +628,21 @@ class SeparableConvLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            conv_out = tf.nn.separable_conv2d(
-                input=X,
-                depthwise_filter=self.W_dw,
-                pointwise_filter=self.W_pw,
-                strides=[1, self.stride, self.stride, 1],
-                padding=self.padding,
-                name=self.get_name()
-            )
-            if self.use_bias:
-                conv_out = tf.nn.bias_add(conv_out, self.b, name=self.get_name() + SeparableConvLayer.BIAS)
-            if self.f is None:
-                return conv_out
-            return self.f(conv_out, name=self.get_name() + SeparableConvLayer.ACTIVATION_PREFIX)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                conv_out = tf.nn.separable_conv2d(
+                    input=X,
+                    depthwise_filter=self.W_dw,
+                    pointwise_filter=self.W_pw,
+                    strides=[1, self.stride, self.stride, 1],
+                    padding=self.padding,
+                    name=self.get_name()
+                )
+                if self.use_bias:
+                    conv_out = tf.nn.bias_add(conv_out, self.b, name=self.get_name() + SeparableConvLayer.BIAS)
+                if self.f is None:
+                    return conv_out
+                return self.f(conv_out, name=self.get_name() + SeparableConvLayer.ACTIVATION_PREFIX)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -753,13 +758,14 @@ class DenseLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            out = tf.matmul(X, self.W, name=self.get_name())
-            if self.use_bias:
-                out = tf.nn.bias_add(out, self.b, name=self.get_name() + DenseLayer.BIAS)
-            if self.f is None:
-                return out
-            return self.f(out, name=self.get_name() + DenseLayer.ACTIVATION_PREFIX)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                out = tf.matmul(X, self.W, name=self.get_name())
+                if self.use_bias:
+                    out = tf.nn.bias_add(out, self.b, name=self.get_name() + DenseLayer.BIAS)
+                if self.f is None:
+                    return out
+                return self.f(out, name=self.get_name() + DenseLayer.ACTIVATION_PREFIX)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -880,17 +886,18 @@ class AtrousConvLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            conv_out = tf.nn.atrous_conv2d(X, self.W,
-                                           self.rate,
-                                           self.padding,
-                                           name=self.get_name()
-            )
-            if self.use_bias:
-                conv_out = tf.nn.bias_add(conv_out, self.b, name=self.get_name() + AtrousConvLayer.BIAS)
-            if self.f is None:
-                return conv_out
-            return self.f(conv_out, name=self.get_name() + AtrousConvLayer.ACTIVATION_PREFIX)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                conv_out = tf.nn.atrous_conv2d(X, self.W,
+                                               self.rate,
+                                               self.padding,
+                                               name=self.get_name()
+                )
+                if self.use_bias:
+                    conv_out = tf.nn.bias_add(conv_out, self.b, name=self.get_name() + AtrousConvLayer.BIAS)
+                if self.f is None:
+                    return conv_out
+                return self.f(conv_out, name=self.get_name() + AtrousConvLayer.ACTIVATION_PREFIX)
 
     def _training_forward(self, x):
         return self._forward(x, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -994,18 +1001,45 @@ class BatchNormLayer(BatchNormBaseLayer):
         self._named_params_dict[self.name_var] = self.running_variance
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            if self._track_running_stats:
-                return tf.nn.batch_normalization(
-                    X,
-                    self.running_mean,
-                    self.running_variance,
-                    self.beta,
-                    self.gamma,
-                    self.eps,
-                    name=self.get_name()
-                )
-            else:
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                if self._track_running_stats:
+                    return tf.nn.batch_normalization(
+                        X,
+                        self.running_mean,
+                        self.running_variance,
+                        self.beta,
+                        self.gamma,
+                        self.eps,
+                        name=self.get_name()
+                    )
+                else:
+                    # These if statements check if we do batchnorm for convolution or dense
+                    if len(X.shape) == 4:
+                        # conv
+                        axes = [0, 1, 2]
+                    else:
+                        # dense
+                        axes = [0]
+
+                    batch_mean, batch_var = tf.nn.moments(X, axes=axes)
+
+                    return tf.nn.batch_normalization(
+                        X,
+                        batch_mean,
+                        batch_var,
+                        self.beta,
+                        self.gamma,
+                        self.eps,
+                        name=self.get_name()
+                    )
+
+    def _training_forward(self, X):
+        if not self._track_running_stats:
+            return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
+
+        with tf.name_scope(MakiRestorable.TRAINING_MODE):
+            with tf.name_scope(self.get_name()):
                 # These if statements check if we do batchnorm for convolution or dense
                 if len(X.shape) == 4:
                     # conv
@@ -1016,50 +1050,26 @@ class BatchNormLayer(BatchNormBaseLayer):
 
                 batch_mean, batch_var = tf.nn.moments(X, axes=axes)
 
-                return tf.nn.batch_normalization(
-                    X,
-                    batch_mean,
-                    batch_var,
-                    self.beta,
-                    self.gamma,
-                    self.eps,
-                    name=self.get_name()
+                update_running_mean = tf.assign(
+                    self.running_mean,
+                    self.running_mean * self.decay + batch_mean * (1 - self.decay)
                 )
+                update_running_variance = tf.assign(
+                    self.running_variance,
+                    self.running_variance * self.decay + batch_var * (1 - self.decay)
+                )
+                with tf.control_dependencies([update_running_mean, update_running_variance]):
+                    out = tf.nn.batch_normalization(
+                        X,
+                        batch_mean,
+                        batch_var,
+                        self.beta,
+                        self.gamma,
+                        self.eps,
+                        name=self.get_name()
+                    )
 
-    def _training_forward(self, X):
-        if not self._track_running_stats:
-            return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
-
-        # These if statements check if we do batchnorm for convolution or dense
-        if len(X.shape) == 4:
-            # conv
-            axes = [0, 1, 2]
-        else:
-            # dense
-            axes = [0]
-
-        batch_mean, batch_var = tf.nn.moments(X, axes=axes)
-
-        update_running_mean = tf.assign(
-            self.running_mean,
-            self.running_mean * self.decay + batch_mean * (1 - self.decay)
-        )
-        update_running_variance = tf.assign(
-            self.running_variance,
-            self.running_variance * self.decay + batch_var * (1 - self.decay)
-        )
-        with tf.control_dependencies([update_running_mean, update_running_variance]):
-            out = tf.nn.batch_normalization(
-                X,
-                batch_mean,
-                batch_var,
-                self.beta,
-                self.gamma,
-                self.eps,
-                name=self.get_name()
-            )
-
-        return out
+                return out
 
     @staticmethod
     def build(params: dict):
@@ -1170,84 +1180,87 @@ class GroupNormLayer(BatchNormBaseLayer):
         self._named_params_dict[self.name_var] = self.running_variance
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            # These if statements check if we do batchnorm for convolution or dense
-            if len(X.shape) == 4:
-                # conv
-                axes = [1, 2, 4]
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                # These if statements check if we do batchnorm for convolution or dense
+                if len(X.shape) == 4:
+                    # conv
+                    axes = [1, 2, 4]
 
-                N, H, W, C = X.shape
-                old_shape = [N, H, W, C]
-                X = tf.reshape(X, [N, H, W, self.G, C // self.G])
-            else:
-                # dense
-                axes = [2]
+                    N, H, W, C = X.shape
+                    old_shape = [N, H, W, C]
+                    X = tf.reshape(X, [N, H, W, self.G, C // self.G])
+                else:
+                    # dense
+                    axes = [2]
 
-                N, F = X.shape
-                old_shape = [N, F]
-                X = tf.reshape(X, [N, self.G, F // self.G])
+                    N, F = X.shape
+                    old_shape = [N, F]
+                    X = tf.reshape(X, [N, self.G, F // self.G])
 
-            if self._track_running_stats:
-                X = (X - self.running_mean) / tf.sqrt(self.running_variance + self.eps)
-            else:
-                # Output shape [N, 1, 1, self.G, 1] for Conv and [N, G, 1] for Dense
-                batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
-                X = (X - batch_mean) / tf.sqrt(batch_var + self.eps)
+                if self._track_running_stats:
+                    X = (X - self.running_mean) / tf.sqrt(self.running_variance + self.eps)
+                else:
+                    # Output shape [N, 1, 1, self.G, 1] for Conv and [N, G, 1] for Dense
+                    batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
+                    X = (X - batch_mean) / tf.sqrt(batch_var + self.eps)
 
-            X = tf.reshape(X, old_shape)
+                X = tf.reshape(X, old_shape)
 
-            if self.gamma is not None:
-                X *= self.gamma
+                if self.gamma is not None:
+                    X *= self.gamma
 
-            if self.beta is not None:
-                X += self.beta
+                if self.beta is not None:
+                    X += self.beta
 
-            return X
+                return X
 
     def _training_forward(self, X):
         if not self._track_running_stats:
             return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
 
-        # These if statements check if we do batchnorm for convolution or dense
-        if len(X.shape) == 4:
-            # conv
-            axes = [1, 2, 4]
+        with tf.name_scope(MakiRestorable.TRAINING_MODE):
+            with tf.name_scope(self.get_name()):
+                # These if statements check if we do batchnorm for convolution or dense
+                if len(X.shape) == 4:
+                    # conv
+                    axes = [1, 2, 4]
 
-            N, H, W, C = X.shape
-            old_shape = [N, H, W, C]
-            X = tf.reshape(X, [N, H, W, self.G, C // self.G])
-        else:
-            # dense
-            axes = [2]
+                    N, H, W, C = X.shape
+                    old_shape = [N, H, W, C]
+                    X = tf.reshape(X, [N, H, W, self.G, C // self.G])
+                else:
+                    # dense
+                    axes = [2]
 
-            N, F = X.shape
-            old_shape = [N, F]
-            X = tf.reshape(X, [N, self.G, F // self.G])
+                    N, F = X.shape
+                    old_shape = [N, F]
+                    X = tf.reshape(X, [N, self.G, F // self.G])
 
-        # Output shape [N, 1, 1, self.G, 1] for Conv and [N, G, 1] for Dense
-        batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
+                # Output shape [N, 1, 1, self.G, 1] for Conv and [N, G, 1] for Dense
+                batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
 
-        update_running_mean = tf.assign(
-            self.running_mean,
-            self.running_mean * self.decay + batch_mean * (1 - self.decay)
-        )
-        update_running_variance = tf.assign(
-            self.running_variance,
-            self.running_variance * self.decay + batch_var * (1 - self.decay)
-        )
+                update_running_mean = tf.assign(
+                    self.running_mean,
+                    self.running_mean * self.decay + batch_mean * (1 - self.decay)
+                )
+                update_running_variance = tf.assign(
+                    self.running_variance,
+                    self.running_variance * self.decay + batch_var * (1 - self.decay)
+                )
 
-        with tf.control_dependencies([update_running_mean, update_running_variance]):
-            X = (X - batch_mean) / tf.sqrt(batch_var + self.eps)
+                with tf.control_dependencies([update_running_mean, update_running_variance]):
+                    X = (X - batch_mean) / tf.sqrt(batch_var + self.eps)
 
-            X = tf.reshape(X, old_shape)
+                    X = tf.reshape(X, old_shape)
 
-            if self.gamma is not None:
-                X *= self.gamma
+                    if self.gamma is not None:
+                        X *= self.gamma
 
-            if self.beta is not None:
-                X += self.beta
+                    if self.beta is not None:
+                        X += self.beta
 
-        return X
+                return X
 
     @staticmethod
     def build(params: dict):
@@ -1355,18 +1368,46 @@ class NormalizationLayer(BatchNormBaseLayer):
         self._named_params_dict[self.name_var] = self.running_variance
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            if self._track_running_stats:
-                return tf.nn.batch_normalization(
-                    X,
-                    self.running_mean,
-                    self.running_variance,
-                    self.beta,
-                    self.gamma,
-                    self.eps,
-                    name=self.get_name()
-                )
-            else:
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                if self._track_running_stats:
+                    return tf.nn.batch_normalization(
+                        X,
+                        self.running_mean,
+                        self.running_variance,
+                        self.beta,
+                        self.gamma,
+                        self.eps,
+                        name=self.get_name()
+                    )
+                else:
+                    # These if statements check if we do batchnorm for convolution or dense
+                    if len(X.shape) == 4:
+                        # conv
+                        axes = [1, 2, 3]
+                    else:
+                        # dense
+                        axes = [1]
+
+                    # Output shape [N, 1, 1, 1] for Conv and [N, 1] for Dense
+                    batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
+
+                    return tf.nn.batch_normalization(
+                        X,
+                        batch_mean,
+                        batch_var,
+                        self.beta,
+                        self.gamma,
+                        self.eps,
+                        name=self.get_name()
+                    )
+
+    def _training_forward(self, X):
+        if not self._track_running_stats:
+            return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
+
+        with tf.name_scope(MakiRestorable.TRAINING_MODE):
+            with tf.name_scope(self.get_name()):
                 # These if statements check if we do batchnorm for convolution or dense
                 if len(X.shape) == 4:
                     # conv
@@ -1378,52 +1419,27 @@ class NormalizationLayer(BatchNormBaseLayer):
                 # Output shape [N, 1, 1, 1] for Conv and [N, 1] for Dense
                 batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
 
-                return tf.nn.batch_normalization(
-                    X,
-                    batch_mean,
-                    batch_var,
-                    self.beta,
-                    self.gamma,
-                    self.eps,
-                    name=self.get_name()
+                update_running_mean = tf.assign(
+                    self.running_mean,
+                    self.running_mean * self.decay + batch_mean * (1 - self.decay)
+                )
+                update_running_variance = tf.assign(
+                    self.running_variance,
+                    self.running_variance * self.decay + batch_var * (1 - self.decay)
                 )
 
-    def _training_forward(self, X):
-        if not self._track_running_stats:
-            return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
+                with tf.control_dependencies([update_running_mean, update_running_variance]):
+                    X = tf.nn.batch_normalization(
+                        X,
+                        batch_mean,
+                        batch_var,
+                        self.beta,
+                        self.gamma,
+                        self.eps,
+                        name=self.get_name()
+                    )
 
-        # These if statements check if we do batchnorm for convolution or dense
-        if len(X.shape) == 4:
-            # conv
-            axes = [1, 2, 3]
-        else:
-            # dense
-            axes = [1]
-
-        # Output shape [N, 1, 1, 1] for Conv and [N, 1] for Dense
-        batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
-
-        update_running_mean = tf.assign(
-            self.running_mean,
-            self.running_mean * self.decay + batch_mean * (1 - self.decay)
-        )
-        update_running_variance = tf.assign(
-            self.running_variance,
-            self.running_variance * self.decay + batch_var * (1 - self.decay)
-        )
-
-        with tf.control_dependencies([update_running_mean, update_running_variance]):
-            X = tf.nn.batch_normalization(
-                X,
-                batch_mean,
-                batch_var,
-                self.beta,
-                self.gamma,
-                self.eps,
-                name=self.get_name()
-            )
-
-        return X
+                return X
 
     @staticmethod
     def build(params: dict):
@@ -1532,18 +1548,46 @@ class InstanceNormLayer(BatchNormBaseLayer):
         self._named_params_dict[self.name_var] = self.running_variance
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            if self._track_running_stats:
-                return tf.nn.batch_normalization(
-                    X,
-                    self.running_mean,
-                    self.running_variance,
-                    self.beta,
-                    self.gamma,
-                    self.eps,
-                    name=self.get_name()
-                )
-            else:
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                if self._track_running_stats:
+                    return tf.nn.batch_normalization(
+                        X,
+                        self.running_mean,
+                        self.running_variance,
+                        self.beta,
+                        self.gamma,
+                        self.eps,
+                        name=self.get_name()
+                    )
+                else:
+                    # These if statements check if we do batchnorm for convolution or dense
+                    if len(X.shape) == 4:
+                        # conv
+                        axes = [1, 2]
+                    else:
+                        # dense
+                        axes = [1]
+
+                    # Output shape [N, 1, 1, C] for Conv and [N, F] for Dense
+                    batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
+
+                    return tf.nn.batch_normalization(
+                        X,
+                        batch_mean,
+                        batch_var,
+                        self.beta,
+                        self.gamma,
+                        self.eps,
+                        name=self.get_name()
+                    )
+
+    def _training_forward(self, X):
+        if not self._track_running_stats:
+            return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
+
+        with tf.name_scope(MakiRestorable.TRAINING_MODE):
+            with tf.name_scope(self.get_name()):
                 # These if statements check if we do batchnorm for convolution or dense
                 if len(X.shape) == 4:
                     # conv
@@ -1551,56 +1595,31 @@ class InstanceNormLayer(BatchNormBaseLayer):
                 else:
                     # dense
                     axes = [1]
+                with tf.name_scope(self.get_name() + MakiRestorable.TRAINING_MODE):
+                    # Output shape [N, 1, 1, C] for Conv and [N, F] for Dense
+                    batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
 
-                # Output shape [N, 1, 1, C] for Conv and [N, F] for Dense
-                batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
+                    update_running_mean = tf.assign(
+                        self.running_mean,
+                        self.running_mean * self.decay + batch_mean * (1 - self.decay)
+                    )
+                    update_running_variance = tf.assign(
+                        self.running_variance,
+                        self.running_variance * self.decay + batch_var * (1 - self.decay)
+                    )
 
-                return tf.nn.batch_normalization(
-                    X,
-                    batch_mean,
-                    batch_var,
-                    self.beta,
-                    self.gamma,
-                    self.eps,
-                    name=self.get_name()
-                )
+                    with tf.control_dependencies([update_running_mean, update_running_variance]):
+                        X = tf.nn.batch_normalization(
+                            X,
+                            batch_mean,
+                            batch_var,
+                            self.beta,
+                            self.gamma,
+                            self.eps,
+                            name=self.get_name()
+                        )
 
-    def _training_forward(self, X):
-        if not self._track_running_stats:
-            return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
-
-        # These if statements check if we do batchnorm for convolution or dense
-        if len(X.shape) == 4:
-            # conv
-            axes = [1, 2]
-        else:
-            # dense
-            axes = [1]
-        with tf.name_scope(self.get_name() + MakiRestorable.TRAINING_MODE):
-            # Output shape [N, 1, 1, C] for Conv and [N, F] for Dense
-            batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
-
-            update_running_mean = tf.assign(
-                self.running_mean,
-                self.running_mean * self.decay + batch_mean * (1 - self.decay)
-            )
-            update_running_variance = tf.assign(
-                self.running_variance,
-                self.running_variance * self.decay + batch_var * (1 - self.decay)
-            )
-
-            with tf.control_dependencies([update_running_mean, update_running_variance]):
-                X = tf.nn.batch_normalization(
-                    X,
-                    batch_mean,
-                    batch_var,
-                    self.beta,
-                    self.gamma,
-                    self.eps,
-                    name=self.get_name()
-                )
-
-            return X
+                    return X
 
     @staticmethod
     def build(params: dict):
@@ -1665,8 +1684,9 @@ class ScaleLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            return tf.math.multiply(X, self.scale, name=self.get_name())
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                return tf.math.multiply(X, self.scale, name=self.get_name())
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)

--- a/makiflow/layers/trainable_layers.py
+++ b/makiflow/layers/trainable_layers.py
@@ -102,10 +102,10 @@ class ConvLayer(SimpleForwardLayer):
                          named_params_dict=named_params_dict
         )
 
-    def _forward(self, x, type_graph_operation=MakiRestorable.TEST_PREFIX):
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
         with tf.name_scope(type_graph_operation + super().get_name()):
             conv_out = tf.nn.conv2d(
-                x, self.W,
+                X, self.W,
                 strides=[1, self.stride, self.stride, 1],
                 padding=self.padding,
                 name=self._name
@@ -238,15 +238,15 @@ class UpConvLayer(SimpleForwardLayer):
                          named_params_dict=named_params_dict
         )
 
-    def _forward(self, x, type_graph_operation=MakiRestorable.TEST_PREFIX):
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
         with tf.name_scope(type_graph_operation + super().get_name()):
-            out_shape = x.get_shape().as_list()
+            out_shape = X.get_shape().as_list()
             out_shape[1] *= self.size[0]
             out_shape[2] *= self.size[1]
             # out_f
             out_shape[3] = self.shape[2]
             conv_out = tf.nn.conv2d_transpose(
-                x, self.W,
+                X, self.W,
                 output_shape=out_shape, strides=self.strides, padding=self.padding,
                 name=self._name
             )
@@ -1498,7 +1498,7 @@ class InstanceNormLayer(BatchNormBaseLayer):
                                             name=self.name_var)
         self._named_params_dict[self.name_var] = self.running_variance
 
-    def _forward(self, x, type_graph_operation=MakiRestorable.TEST_PREFIX):
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
         with tf.name_scope(type_graph_operation + super().get_name()):
             if self._track_running_stats:
                 return tf.nn.batch_normalization(

--- a/makiflow/layers/trainable_layers.py
+++ b/makiflow/layers/trainable_layers.py
@@ -106,7 +106,7 @@ class ConvLayer(SimpleForwardLayer):
         )
 
     def _forward(self, x, prefix_operation=MakiRestorable.TEST_PREFIX):
-        with tf.name_scope(ConvLayer.TYPE + prefix_operation):
+        with tf.name_scope(super().get_name() + prefix_operation):
             conv_out = tf.nn.conv2d(
                 x, self.W,
                 strides=[1, self.stride, self.stride, 1],
@@ -242,7 +242,7 @@ class UpConvLayer(SimpleForwardLayer):
         )
 
     def _forward(self, x, prefix_operation=MakiRestorable.TEST_PREFIX):
-        with tf.name_scope(UpConvLayer.TYPE + prefix_operation):
+        with tf.name_scope(super().get_name() + prefix_operation):
             out_shape = x.get_shape().as_list()
             out_shape[1] *= self.size[0]
             out_shape[2] *= self.size[1]
@@ -1502,7 +1502,7 @@ class InstanceNormLayer(BatchNormBaseLayer):
         self._named_params_dict[self.name_var] = self.running_variance
 
     def _forward(self, X, prefix_operation=MakiRestorable.TEST_PREFIX):
-        with tf.name_scope(InstanceNormLayer.TYPE + prefix_operation):
+        with tf.name_scope(super().get_name() + prefix_operation):
             if self._track_running_stats:
                 return tf.nn.batch_normalization(
                     X,
@@ -1546,7 +1546,7 @@ class InstanceNormLayer(BatchNormBaseLayer):
         else:
             # dense
             axes = [1]
-        with tf.name_scope(InstanceNormLayer.TYPE + MakiRestorable.TRAINING_PREFIX):
+        with tf.name_scope(super().get_name() + MakiRestorable.TRAINING_PREFIX):
             # Output shape [N, 1, 1, C] for Conv and [N, F] for Dense
             batch_mean, batch_var = tf.nn.moments(X, axes=axes, keep_dims=True)
 

--- a/makiflow/layers/trainable_layers.py
+++ b/makiflow/layers/trainable_layers.py
@@ -38,9 +38,6 @@ class ConvLayer(SimpleForwardLayer):
     BIAS = '/bias'
     ACTIVATION = '/activation'
 
-    TRAINING_PREFIX = '/training'
-    TEST_PREFIX = '/inference'
-
     NAME_BIAS = 'ConvBias_{}x{}_in{}_out{}_id_{}'
     NAME_CONV_W = 'ConvKernel_{}x{}_in{}_out{}_id_{}'
 
@@ -105,8 +102,8 @@ class ConvLayer(SimpleForwardLayer):
                          named_params_dict=named_params_dict
         )
 
-    def _forward(self, x, prefix_operation=MakiRestorable.TEST_PREFIX):
-        with tf.name_scope(super().get_name() + prefix_operation):
+    def _forward(self, x, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
             conv_out = tf.nn.conv2d(
                 x, self.W,
                 strides=[1, self.stride, self.stride, 1],
@@ -241,8 +238,8 @@ class UpConvLayer(SimpleForwardLayer):
                          named_params_dict=named_params_dict
         )
 
-    def _forward(self, x, prefix_operation=MakiRestorable.TEST_PREFIX):
-        with tf.name_scope(super().get_name() + prefix_operation):
+    def _forward(self, x, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
             out_shape = x.get_shape().as_list()
             out_shape[1] *= self.size[0]
             out_shape[2] *= self.size[1]
@@ -1501,8 +1498,8 @@ class InstanceNormLayer(BatchNormBaseLayer):
                                             name=self.name_var)
         self._named_params_dict[self.name_var] = self.running_variance
 
-    def _forward(self, X, prefix_operation=MakiRestorable.TEST_PREFIX):
-        with tf.name_scope(super().get_name() + prefix_operation):
+    def _forward(self, x, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
             if self._track_running_stats:
                 return tf.nn.batch_normalization(
                     X,

--- a/makiflow/layers/untrainable_layers.py
+++ b/makiflow/layers/untrainable_layers.py
@@ -270,11 +270,12 @@ class ConcatLayer(MakiLayer):
         )
         return maki_tensor
 
-    def _forward(self, X):
-        return tf.concat(values=X, axis=self.axis, name=self._name)
+    def _forward(self, X, prefix_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(super().get_name() + prefix_operation):
+            return tf.concat(values=X, axis=self.axis, name=self._name)
 
     def _training_forward(self, X):
-        return self._forward(X)
+        return self._forward(X, MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -657,7 +658,7 @@ class ActivationLayer(SimpleForwardLayer):
 
 
     def _forward(self, x, prefix_operation=MakiRestorable.TEST_PREFIX):
-        with tf.name_scope(ActivationLayer.TYPE + prefix_operation):
+        with tf.name_scope(super().get_name() + prefix_operation):
             return self.f(x, name=self._name)
 
     def _training_forward(self, X):

--- a/makiflow/layers/untrainable_layers.py
+++ b/makiflow/layers/untrainable_layers.py
@@ -270,7 +270,7 @@ class ConcatLayer(MakiLayer):
         )
         return maki_tensor
 
-    def _forward(self, x, type_graph_operation=MakiRestorable.TEST_PREFIX):
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
         with tf.name_scope(type_graph_operation + super().get_name()):
             return tf.concat(values=X, axis=self.axis, name=self._name)
 
@@ -657,9 +657,9 @@ class ActivationLayer(SimpleForwardLayer):
         )
 
 
-    def _forward(self, x, type_graph_operation=MakiRestorable.TEST_PREFIX):
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
         with tf.name_scope(type_graph_operation + super().get_name()):
-            return self.f(x, name=self._name)
+            return self.f(X, name=self._name)
 
     def _training_forward(self, X):
         return self._forward(X, MakiRestorable.TRAINING_PREFIX)

--- a/makiflow/layers/untrainable_layers.py
+++ b/makiflow/layers/untrainable_layers.py
@@ -658,7 +658,8 @@ class ActivationLayer(SimpleForwardLayer):
 
     def _forward(self, x):
         with tf.name_scope(ActivationLayer.TYPE):
-            return self.f(x, name=self._name)
+            with tf.name_scope(MakiRestorable.OP):
+                return self.f(x, name=self._name)
 
     def _training_forward(self, X):
         return self._forward(X)

--- a/makiflow/layers/untrainable_layers.py
+++ b/makiflow/layers/untrainable_layers.py
@@ -25,6 +25,8 @@ from makiflow.layers.sf_layer import SimpleForwardLayer
 
 class InputLayer(InputMakiLayer):
 
+    _ERROR_STRING_IS_NOT_IMPLEMENTED = 'This functionality is not implemented in the InputLayer.'
+
     def __init__(self, input_shape, name):
         """
         InputLayer is used to instantiate MakiFlow tensor.
@@ -38,32 +40,38 @@ class InputLayer(InputMakiLayer):
         """
         self._name = str(name)
         self._input_shape = input_shape
+
         self._input = tf.placeholder(tf.float32, shape=input_shape, name=self._name)
+
         super().__init__(
             data_tensor=self._input,
             name=name
         )
 
     def __call__(self, x):
-        raise RuntimeError('This functionality is not implemented in the InputLayer.')
+        raise RuntimeError(InputLayer._ERROR_STRING_IS_NOT_IMPLEMENTED)
 
     def _training_forward(self, x):
-        raise RuntimeError('This functionality is not implemented in the InputLayer.')
+        raise RuntimeError(InputLayer._ERROR_STRING_IS_NOT_IMPLEMENTED)
 
     @staticmethod
     def build(params: dict):
         input_shape = params[InputLayer.INPUT_SHAPE]
         name = params[MakiRestorable.NAME]
-        return InputLayer(name=name, input_shape=input_shape)
+
+        return InputLayer(
+            name=name,
+            input_shape=input_shape
+        )
 
     def to_dict(self):
         return {
-            MakiRestorable.NAME: self._name,
-            MakiTensor.PARENT_TENSOR_NAMES: None,
+            MakiRestorable.NAME: super().get_name(),
+            MakiTensor.PARENT_TENSOR_NAMES: super().get_parent_tensor_names(),
             MakiRestorable.FIELD_TYPE: InputMakiLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
-                InputMakiLayer.INPUT_SHAPE: self._input_shape
+                MakiRestorable.NAME: super().get_name(),
+                InputMakiLayer.INPUT_SHAPE: super().get_shape()
             }
         }
 
@@ -83,15 +91,16 @@ class ReshapeLayer(SimpleForwardLayer):
         name : str
             Name of this layer.
         """
+        self.new_shape = new_shape
 
         super().__init__(name, params=[],
                          regularize_params=[],
                          named_params_dict={}
         )
-        self.new_shape = new_shape
 
     def _forward(self, x):
-        return tf.reshape(tensor=x, shape=self.new_shape, name=self._name)
+        with tf.name_scope(ReshapeLayer.TYPE):
+            return tf.reshape(tensor=x, shape=self.new_shape, name=self._name)
 
     def _training_forward(self, x):
         return self._forward(x)
@@ -100,6 +109,7 @@ class ReshapeLayer(SimpleForwardLayer):
     def build(params: dict):
         name = params[MakiRestorable.NAME]
         new_shape = params[ReshapeLayer.NEW_SHAPE]
+
         return ReshapeLayer(
             new_shape=new_shape,
             name=name
@@ -109,7 +119,7 @@ class ReshapeLayer(SimpleForwardLayer):
         return {
             MakiRestorable.FIELD_TYPE: ReshapeLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
                 ReshapeLayer.NEW_SHAPE: self.new_shape
             }
         }
@@ -147,13 +157,17 @@ class MulByAlphaLayer(SimpleForwardLayer):
     def build(params: dict):
         name = params[MakiRestorable.NAME]
         alpha = params[MulByAlphaLayer.ALPHA]
-        return MulByAlphaLayer(alpha=alpha, name=name)
+
+        return MulByAlphaLayer(
+            alpha=alpha,
+            name=name
+        )
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: MulByAlphaLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
                 MulByAlphaLayer.ALPHA: self.alpha,
             }
         }
@@ -204,13 +218,14 @@ class SumLayer(MakiLayer):
     @staticmethod
     def build(params: dict):
         name = params[MakiRestorable.NAME]
+
         return SumLayer(name=name)
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: SumLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
             }
         }
 
@@ -231,6 +246,7 @@ class ConcatLayer(MakiLayer):
             Name of this layer.
         """
         self.axis = axis
+
         super().__init__(name, params=[],
                          regularize_params=[],
                          named_params_dict={}
@@ -264,13 +280,17 @@ class ConcatLayer(MakiLayer):
     def build(params: dict):
         name = params[MakiRestorable.NAME]
         axis = params[ConcatLayer.AXIS]
-        return ConcatLayer(name=name, axis=axis)
+
+        return ConcatLayer(
+            name=name,
+            axis=axis
+        )
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: ConcatLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
                 ConcatLayer.AXIS: self.axis,
             }
         }
@@ -297,6 +317,7 @@ class ZeroPaddingLayer(SimpleForwardLayer):
 
         self.input_padding = padding
         self.padding = [[0, 0], padding[0], padding[1], [0, 0]]
+
         super().__init__(name, params=[],
                          regularize_params=[],
                          named_params_dict={}
@@ -318,13 +339,17 @@ class ZeroPaddingLayer(SimpleForwardLayer):
     def build(params: dict):
         name = params[MakiRestorable.NAME]
         padding = params[ZeroPaddingLayer.PADDING]
-        return ZeroPaddingLayer(padding=padding, name=name)
+
+        return ZeroPaddingLayer(
+            padding=padding,
+            name=name
+        )
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: ZeroPaddingLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
                 ZeroPaddingLayer.PADDING: self.input_padding,
             }
         }
@@ -359,13 +384,14 @@ class GlobalMaxPoolLayer(SimpleForwardLayer):
     @staticmethod
     def build(params: dict):
         name = params[MakiRestorable.NAME]
+
         return GlobalMaxPoolLayer(name=name)
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: GlobalMaxPoolLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
             }
         }
 
@@ -399,13 +425,14 @@ class GlobalAvgPoolLayer(SimpleForwardLayer):
     @staticmethod
     def build(params: dict):
         name = params[MakiRestorable.NAME]
+
         return GlobalAvgPoolLayer(name=name)
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: GlobalAvgPoolLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
             }
         }
 
@@ -434,6 +461,7 @@ class MaxPoolLayer(SimpleForwardLayer):
         self.ksize = ksize
         self.strides = strides
         self.padding = padding
+
         super().__init__(name, params=[],
                          regularize_params=[],
                          named_params_dict={}
@@ -457,14 +485,19 @@ class MaxPoolLayer(SimpleForwardLayer):
         ksize = params[MaxPoolLayer.KSIZE]
         strides = params[MaxPoolLayer.STRIDES]
         padding = params[MaxPoolLayer.PADDING]
-        return MaxPoolLayer(name=name, ksize=ksize,
-                            strides=strides, padding=padding)
+
+        return MaxPoolLayer(
+            name=name,
+            ksize=ksize,
+            strides=strides,
+            padding=padding
+        )
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: MaxPoolLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
                 MaxPoolLayer.KSIZE: self.ksize,
                 MaxPoolLayer.STRIDES: self.strides,
                 MaxPoolLayer.PADDING: self.padding
@@ -496,6 +529,7 @@ class AvgPoolLayer(SimpleForwardLayer):
         self.ksize = ksize
         self.strides = strides
         self.padding = padding
+
         super().__init__(name, params=[],
                          regularize_params=[],
                          named_params_dict={}
@@ -521,15 +555,17 @@ class AvgPoolLayer(SimpleForwardLayer):
         name = params[MakiRestorable.NAME]
 
         return AvgPoolLayer(
-            ksize=ksize, strides=strides,
-            padding=padding, name=name
+            ksize=ksize,
+            strides=strides,
+            padding=padding,
+            name=name
         )
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: AvgPoolLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
                 AvgPoolLayer.KSIZE: self.ksize,
                 AvgPoolLayer.STRIDES: self.strides,
                 AvgPoolLayer.PADDING: self.padding
@@ -555,6 +591,7 @@ class UpSamplingLayer(SimpleForwardLayer):
             Name of this layer.
         """
         self.size = size
+
         super().__init__(name, params=[],
                          regularize_params=[],
                          named_params_dict={}
@@ -576,13 +613,17 @@ class UpSamplingLayer(SimpleForwardLayer):
     def build(params: dict):
         name = params[MakiRestorable.NAME]
         size = params[UpSamplingLayer.SIZE]
-        return UpSamplingLayer(name=name, size=size)
+
+        return UpSamplingLayer(
+            name=name,
+            size=size
+        )
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: UpSamplingLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
                 UpSamplingLayer.SIZE: self.size
             }
         }
@@ -591,6 +632,8 @@ class UpSamplingLayer(SimpleForwardLayer):
 class ActivationLayer(SimpleForwardLayer):
     TYPE = 'ActivationLayer'
     ACTIVATION = 'activation'
+
+    _ERROR_ACTIVATION_INPUT_NONE = "Activation can't None"
 
     def __init__(self, name, activation=tf.nn.relu):
         """
@@ -604,8 +647,9 @@ class ActivationLayer(SimpleForwardLayer):
             Name of this layer.
         """
         if activation is None:
-            raise Exception("Activation can't None")
+            raise Exception(ActivationLayer._ERROR_ACTIVATION_INPUT_NONE)
         self.f = activation
+
         super().__init__(name, params=[],
                          regularize_params=[],
                          named_params_dict={}
@@ -613,7 +657,8 @@ class ActivationLayer(SimpleForwardLayer):
 
 
     def _forward(self, x):
-        return self.f(x, name=self._name)
+        with tf.name_scope(ActivationLayer.TYPE):
+            return self.f(x, name=self._name)
 
     def _training_forward(self, X):
         return self._forward(X)
@@ -622,13 +667,17 @@ class ActivationLayer(SimpleForwardLayer):
     def build(params: dict):
         activation = ActivationConverter.str_to_activation(params[ActivationLayer.ACTIVATION])
         name = params[MakiRestorable.NAME]
-        return ActivationLayer(activation=activation, name=name)
+
+        return ActivationLayer(
+            activation=activation,
+            name=name
+        )
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: ActivationLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
                 ActivationLayer.ACTIVATION: ActivationConverter.activation_to_str(self.f)
             }
         }
@@ -662,13 +711,14 @@ class FlattenLayer(SimpleForwardLayer):
     @staticmethod
     def build(params: dict):
         name = params[MakiRestorable.NAME]
+
         return FlattenLayer(name=name)
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: FlattenLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name
+                MakiRestorable.NAME: super().get_name()
             }
         }
 
@@ -699,6 +749,7 @@ class DropoutLayer(SimpleForwardLayer):
         self._p_keep = p_keep
         self.noise_shape = noise_shape
         self.seed = seed
+
         super().__init__(name, params=[],
                          regularize_params=[],
                          named_params_dict={}
@@ -721,14 +772,18 @@ class DropoutLayer(SimpleForwardLayer):
         noise_shape = params[DropoutLayer.NOISE_SHAPE]
         seed = params[DropoutLayer.SEED]
 
-        return DropoutLayer(p_keep=p_keep, name=name, noise_shape=noise_shape,
-                            seed=seed)
+        return DropoutLayer(
+            p_keep=p_keep,
+            name=name,
+            noise_shape=noise_shape,
+            seed=seed
+        )
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: DropoutLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
                 DropoutLayer.P_KEEP: self._p_keep,
                 DropoutLayer.NOISE_SHAPE: self.noise_shape,
                 DropoutLayer.SEED: self.seed
@@ -748,6 +803,8 @@ class ResizeLayer(SimpleForwardLayer):
     NEW_SHAPE = 'new_shape'
     ALIGN_CORNERS = 'align_corners'
 
+    _ERROR_INTERPOLATION_IS_NOT_FOUND = "Interpolation {} don't exist"
+
     def __init__(self, new_shape: list, name, interpolation='bilinear', align_corners=False):
         """
         ResizeLayer resize input MakiTensor to new_shape shape.
@@ -761,6 +818,7 @@ class ResizeLayer(SimpleForwardLayer):
             Name of this layer.
         """
         assert (len(new_shape) == 2)
+
         self.new_shape = new_shape
         self.align_corners = align_corners
         self.interpolation = interpolation
@@ -801,7 +859,9 @@ class ResizeLayer(SimpleForwardLayer):
                 name=self._name,
             )
         else:
-            raise Exception(f"Interpolation {self.interpolation} don't exist")
+            raise Exception(
+                ResizeLayer._ERROR_INTERPOLATION_IS_NOT_FOUND.format(self.interpolation)
+            )
 
     def _training_forward(self, X):
         return self._forward(X)
@@ -813,14 +873,18 @@ class ResizeLayer(SimpleForwardLayer):
         align_corners = params[ResizeLayer.ALIGN_CORNERS]
         interpolation = params[ResizeLayer.FIELD_INTERPOLATION]
 
-        return ResizeLayer(interpolation=interpolation, new_shape=new_shape, name=name,
-                           align_corners=align_corners)
+        return ResizeLayer(
+            interpolation=interpolation,
+            new_shape=new_shape,
+            name=name,
+            align_corners=align_corners
+        )
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: ResizeLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
                 ResizeLayer.FIELD_INTERPOLATION: self.interpolation,
                 ResizeLayer.NEW_SHAPE: self.new_shape,
                 ResizeLayer.ALIGN_CORNERS: self.align_corners,
@@ -838,6 +902,7 @@ class L2NormalizationLayer(SimpleForwardLayer):
         Performs L2 normalization along feature dimension.
         """
         self._eps = eps
+
         super().__init__(name, params=[],
                          regularize_params=[],
                          named_params_dict={}
@@ -855,13 +920,17 @@ class L2NormalizationLayer(SimpleForwardLayer):
     def build(params: dict):
         name = params[MakiRestorable.NAME]
         eps = params[L2NormalizationLayer.EPS]
-        return L2NormalizationLayer(name=name, eps=eps)
+
+        return L2NormalizationLayer(
+            name=name,
+            eps=eps
+        )
 
     def to_dict(self):
         return {
             MakiRestorable.FIELD_TYPE: L2NormalizationLayer.TYPE,
             MakiRestorable.PARAMS: {
-                MakiRestorable.NAME: self._name,
+                MakiRestorable.NAME: super().get_name(),
                 L2NormalizationLayer.EPS: self._eps
             }
         }

--- a/makiflow/layers/untrainable_layers.py
+++ b/makiflow/layers/untrainable_layers.py
@@ -98,12 +98,12 @@ class ReshapeLayer(SimpleForwardLayer):
                          named_params_dict={}
         )
 
-    def _forward(self, x):
-        with tf.name_scope(ReshapeLayer.TYPE):
-            return tf.reshape(tensor=x, shape=self.new_shape, name=self._name)
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            return tf.reshape(tensor=X, shape=self.new_shape, name=self._name)
 
-    def _training_forward(self, x):
-        return self._forward(x)
+    def _training_forward(self, X):
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -147,11 +147,12 @@ class MulByAlphaLayer(SimpleForwardLayer):
                          named_params_dict={}
         )
 
-    def _forward(self, x):
-        return tf.math.multiply(x, self.alpha, name=self._name)
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            return tf.math.multiply(X, self.alpha, name=self._name)
 
     def _training_forward(self, X):
-        return self._forward(X)
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -209,11 +210,12 @@ class SumLayer(MakiLayer):
         )
         return maki_tensor
 
-    def _forward(self, X):
-        return sum(X)
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            return sum(X)
 
     def _training_forward(self, X):
-        return self._forward(X)
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -275,7 +277,7 @@ class ConcatLayer(MakiLayer):
             return tf.concat(values=X, axis=self.axis, name=self._name)
 
     def _training_forward(self, X):
-        return self._forward(X, MakiRestorable.TRAINING_PREFIX)
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -325,16 +327,17 @@ class ZeroPaddingLayer(SimpleForwardLayer):
         )
 
 
-    def _forward(self, x):
-        return tf.pad(
-            tensor=x,
-            paddings=self.padding,
-            mode="CONSTANT",
-            name=self._name
-        )
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            return tf.pad(
+                tensor=X,
+                paddings=self.padding,
+                mode="CONSTANT",
+                name=self._name
+            )
 
-    def _training_forward(self, x):
-        return self._forward(x)
+    def _training_forward(self, X):
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -374,13 +377,13 @@ class GlobalMaxPoolLayer(SimpleForwardLayer):
                          named_params_dict={}
         )
 
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            assert (len(X.shape) == 4)
+            return tf.reduce_max(X, axis=[1, 2], name=self._name)
 
-    def _forward(self, x):
-        assert (len(x.shape) == 4)
-        return tf.reduce_max(x, axis=[1, 2], name=self._name)
-
-    def _training_forward(self, x):
-        return self._forward(x)
+    def _training_forward(self, X):
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -415,13 +418,13 @@ class GlobalAvgPoolLayer(SimpleForwardLayer):
                          named_params_dict={}
         )
 
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            assert (len(X.shape) == 4)
+            return tf.reduce_mean(X, axis=[1, 2], name=self._name)
 
-    def _forward(self, x):
-        assert (len(x.shape) == 4)
-        return tf.reduce_mean(x, axis=[1, 2], name=self._name)
-
-    def _training_forward(self, x):
-        return self._forward(x)
+    def _training_forward(self, X):
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -469,16 +472,17 @@ class MaxPoolLayer(SimpleForwardLayer):
         )
 
 
-    def _forward(self, x):
-        return tf.nn.max_pool(
-            x,
-            ksize=self.ksize,
-            strides=self.strides,
-            padding=self.padding
-        )
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            return tf.nn.max_pool(
+                X,
+                ksize=self.ksize,
+                strides=self.strides,
+                padding=self.padding
+            )
 
-    def _training_forward(self, x):
-        return self._forward(x)
+    def _training_forward(self, X):
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -537,16 +541,17 @@ class AvgPoolLayer(SimpleForwardLayer):
         )
 
 
-    def _forward(self, x):
-        return tf.nn.avg_pool(
-            x,
-            ksize=self.ksize,
-            strides=self.strides,
-            padding=self.padding
-        )
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            return tf.nn.avg_pool(
+                X,
+                ksize=self.ksize,
+                strides=self.strides,
+                padding=self.padding
+            )
 
-    def _training_forward(self, x):
-        return self._forward(x)
+    def _training_forward(self, X):
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -599,16 +604,17 @@ class UpSamplingLayer(SimpleForwardLayer):
         )
 
 
-    def _forward(self, x):
-        t_shape = x.get_shape()
-        im_size = (t_shape[1] * self.size[0], t_shape[2] * self.size[1])
-        return tf.image.resize_nearest_neighbor(
-            x,
-            im_size
-        )
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            t_shape = X.get_shape()
+            im_size = (t_shape[1] * self.size[0], t_shape[2] * self.size[1])
+            return tf.image.resize_nearest_neighbor(
+                X,
+                im_size
+            )
 
-    def _training_forward(self, x):
-        return self._forward(x)
+    def _training_forward(self, X):
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -656,7 +662,6 @@ class ActivationLayer(SimpleForwardLayer):
                          named_params_dict={}
         )
 
-
     def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
         with tf.name_scope(type_graph_operation + super().get_name()):
             return self.f(X, name=self._name)
@@ -703,11 +708,12 @@ class FlattenLayer(SimpleForwardLayer):
         )
 
 
-    def _forward(self, x):
-        return tf.contrib.layers.flatten(x)
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            return tf.contrib.layers.flatten(X)
 
-    def _training_forward(self, x):
-        return self._forward(x)
+    def _training_forward(self, X):
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -756,15 +762,16 @@ class DropoutLayer(SimpleForwardLayer):
                          named_params_dict={}
         )
 
-
-    def _forward(self, x):
-        return x
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            return X
 
     def _training_forward(self, X):
-        return tf.nn.dropout(X, self._p_keep,
-                             noise_shape=self.noise_shape,
-                             seed=self.seed,
-                             )
+        with tf.name_scope(MakiRestorable.TEST_PREFIX + super().get_name()):
+            return tf.nn.dropout(X, self._p_keep,
+                                 noise_shape=self.noise_shape,
+                                 seed=self.seed,
+            )
 
     @staticmethod
     def build(params: dict):
@@ -829,43 +836,43 @@ class ResizeLayer(SimpleForwardLayer):
                          named_params_dict={}
         )
 
-
-    def _forward(self, x):
-        if self.interpolation == ResizeLayer.INTERPOLATION_BILINEAR:
-            return tf.image.resize_bilinear(
-                x,
-                self.new_shape,
-                align_corners=self.align_corners,
-                name=self._name,
-            )
-        elif self.interpolation == ResizeLayer.INTERPOLATION_NEAREST_NEIGHBOR:
-            return tf.image.resize_nearest_neighbor(
-                x,
-                self.new_shape,
-                align_corners=self.align_corners,
-                name=self._name,
-            )
-        elif self.interpolation == ResizeLayer.INTERPOLATION_AREA:
-            return tf.image.resize_area(
-                x,
-                self.new_shape,
-                align_corners=self.align_corners,
-                name=self._name,
-            )
-        elif self.interpolation == ResizeLayer.INTERPOLATION_BICUBIC:
-            return tf.image.resize_bicubic(
-                x,
-                self.new_shape,
-                align_corners=self.align_corners,
-                name=self._name,
-            )
-        else:
-            raise Exception(
-                ResizeLayer._ERROR_INTERPOLATION_IS_NOT_FOUND.format(self.interpolation)
-            )
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            if self.interpolation == ResizeLayer.INTERPOLATION_BILINEAR:
+                return tf.image.resize_bilinear(
+                    X,
+                    self.new_shape,
+                    align_corners=self.align_corners,
+                    name=self._name,
+                )
+            elif self.interpolation == ResizeLayer.INTERPOLATION_NEAREST_NEIGHBOR:
+                return tf.image.resize_nearest_neighbor(
+                    X,
+                    self.new_shape,
+                    align_corners=self.align_corners,
+                    name=self._name,
+                )
+            elif self.interpolation == ResizeLayer.INTERPOLATION_AREA:
+                return tf.image.resize_area(
+                    X,
+                    self.new_shape,
+                    align_corners=self.align_corners,
+                    name=self._name,
+                )
+            elif self.interpolation == ResizeLayer.INTERPOLATION_BICUBIC:
+                return tf.image.resize_bicubic(
+                    X,
+                    self.new_shape,
+                    align_corners=self.align_corners,
+                    name=self._name,
+                )
+            else:
+                raise Exception(
+                    ResizeLayer._ERROR_INTERPOLATION_IS_NOT_FOUND.format(self.interpolation)
+                )
 
     def _training_forward(self, X):
-        return self._forward(X)
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):
@@ -909,13 +916,14 @@ class L2NormalizationLayer(SimpleForwardLayer):
                          named_params_dict={}
         )
 
-    def _forward(self, x):
-        return tf.math.l2_normalize(
-            x=x, epsilon=self._eps, axis=-1, name=self._name
-        )
+    def _forward(self, X, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
+            return tf.math.l2_normalize(
+                x=X, epsilon=self._eps, axis=-1, name=self._name
+            )
 
-    def _training_forward(self, x):
-        return self._forward(x)
+    def _training_forward(self, X):
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):

--- a/makiflow/layers/untrainable_layers.py
+++ b/makiflow/layers/untrainable_layers.py
@@ -138,7 +138,7 @@ class MulByAlphaLayer(SimpleForwardLayer):
         )
 
     def _forward(self, x):
-        return x * self.alpha
+        return tf.math.multiply(x, self.alpha, name=self._name)
 
     def _training_forward(self, X):
         return self._forward(X)
@@ -255,7 +255,7 @@ class ConcatLayer(MakiLayer):
         return maki_tensor
 
     def _forward(self, X):
-        return tf.concat(values=X, axis=self.axis)
+        return tf.concat(values=X, axis=self.axis, name=self._name)
 
     def _training_forward(self, X):
         return self._forward(X)
@@ -308,6 +308,7 @@ class ZeroPaddingLayer(SimpleForwardLayer):
             tensor=x,
             paddings=self.padding,
             mode="CONSTANT",
+            name=self._name
         )
 
     def _training_forward(self, x):
@@ -350,7 +351,7 @@ class GlobalMaxPoolLayer(SimpleForwardLayer):
 
     def _forward(self, x):
         assert (len(x.shape) == 4)
-        return tf.reduce_max(x, axis=[1, 2])
+        return tf.reduce_max(x, axis=[1, 2], name=self._name)
 
     def _training_forward(self, x):
         return self._forward(x)
@@ -390,7 +391,7 @@ class GlobalAvgPoolLayer(SimpleForwardLayer):
 
     def _forward(self, x):
         assert (len(x.shape) == 4)
-        return tf.reduce_mean(x, axis=[1, 2])
+        return tf.reduce_mean(x, axis=[1, 2], name=self._name)
 
     def _training_forward(self, x):
         return self._forward(x)
@@ -612,7 +613,7 @@ class ActivationLayer(SimpleForwardLayer):
 
 
     def _forward(self, x):
-        return self.f(x)
+        return self.f(x, name=self._name)
 
     def _training_forward(self, X):
         return self._forward(X)

--- a/makiflow/layers/untrainable_layers.py
+++ b/makiflow/layers/untrainable_layers.py
@@ -270,8 +270,8 @@ class ConcatLayer(MakiLayer):
         )
         return maki_tensor
 
-    def _forward(self, X, prefix_operation=MakiRestorable.TEST_PREFIX):
-        with tf.name_scope(super().get_name() + prefix_operation):
+    def _forward(self, x, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
             return tf.concat(values=X, axis=self.axis, name=self._name)
 
     def _training_forward(self, X):
@@ -657,8 +657,8 @@ class ActivationLayer(SimpleForwardLayer):
         )
 
 
-    def _forward(self, x, prefix_operation=MakiRestorable.TEST_PREFIX):
-        with tf.name_scope(super().get_name() + prefix_operation):
+    def _forward(self, x, type_graph_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(type_graph_operation + super().get_name()):
             return self.f(x, name=self._name)
 
     def _training_forward(self, X):

--- a/makiflow/layers/untrainable_layers.py
+++ b/makiflow/layers/untrainable_layers.py
@@ -662,7 +662,7 @@ class ActivationLayer(SimpleForwardLayer):
             return self.f(X, name=self._name)
 
     def _training_forward(self, X):
-        return self._forward(X, MakiRestorable.TRAINING_PREFIX)
+        return self._forward(X, type_graph_operation=MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):

--- a/makiflow/layers/untrainable_layers.py
+++ b/makiflow/layers/untrainable_layers.py
@@ -656,13 +656,12 @@ class ActivationLayer(SimpleForwardLayer):
         )
 
 
-    def _forward(self, x):
-        with tf.name_scope(ActivationLayer.TYPE):
-            with tf.name_scope(MakiRestorable.OP):
-                return self.f(x, name=self._name)
+    def _forward(self, x, prefix_operation=MakiRestorable.TEST_PREFIX):
+        with tf.name_scope(ActivationLayer.TYPE + prefix_operation):
+            return self.f(x, name=self._name)
 
     def _training_forward(self, X):
-        return self._forward(X)
+        return self._forward(X, MakiRestorable.TRAINING_PREFIX)
 
     @staticmethod
     def build(params: dict):

--- a/makiflow/layers/untrainable_layers.py
+++ b/makiflow/layers/untrainable_layers.py
@@ -99,8 +99,9 @@ class ReshapeLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            return tf.reshape(tensor=X, shape=self.new_shape, name=self._name)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                return tf.reshape(tensor=X, shape=self.new_shape, name=self._name)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -148,8 +149,9 @@ class MulByAlphaLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            return tf.math.multiply(X, self.alpha, name=self._name)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                return tf.math.multiply(X, self.alpha, name=self._name)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -211,9 +213,10 @@ class SumLayer(MakiLayer):
         return maki_tensor
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            # Compare with tf.reduce_sum and tf.add_n, sum(X) works faster in running session
-            return sum(X)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                # Compare with tf.reduce_sum and tf.add_n, sum(X) works faster in running session
+                return sum(X)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -274,8 +277,9 @@ class ConcatLayer(MakiLayer):
         return maki_tensor
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            return tf.concat(values=X, axis=self.axis, name=self._name)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                return tf.concat(values=X, axis=self.axis, name=self._name)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -329,13 +333,14 @@ class ZeroPaddingLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            return tf.pad(
-                tensor=X,
-                paddings=self.padding,
-                mode=ZeroPaddingLayer.CONSTANT,
-                name=self._name
-            )
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                return tf.pad(
+                    tensor=X,
+                    paddings=self.padding,
+                    mode=ZeroPaddingLayer.CONSTANT,
+                    name=self._name
+                )
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -380,9 +385,10 @@ class GlobalMaxPoolLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            assert (len(X.shape) == 4), GlobalMaxPoolLayer._ASSERT_WRONG_INPUT_SHAPE
-            return tf.reduce_max(X, axis=[1, 2], name=self._name)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                assert (len(X.shape) == 4), GlobalMaxPoolLayer._ASSERT_WRONG_INPUT_SHAPE
+                return tf.reduce_max(X, axis=[1, 2], name=self._name)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -422,9 +428,10 @@ class GlobalAvgPoolLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            assert (len(X.shape) == 4), GlobalAvgPoolLayer._ASSERT_WRONG_INPUT_SHAPE
-            return tf.reduce_mean(X, axis=[1, 2], name=self._name)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                assert (len(X.shape) == 4), GlobalAvgPoolLayer._ASSERT_WRONG_INPUT_SHAPE
+                return tf.reduce_mean(X, axis=[1, 2], name=self._name)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -480,13 +487,14 @@ class MaxPoolLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            return tf.nn.max_pool(
-                X,
-                ksize=self.ksize,
-                strides=self.strides,
-                padding=self.padding
-            )
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                return tf.nn.max_pool(
+                    X,
+                    ksize=self.ksize,
+                    strides=self.strides,
+                    padding=self.padding
+                )
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -553,13 +561,14 @@ class AvgPoolLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            return tf.nn.avg_pool(
-                X,
-                ksize=self.ksize,
-                strides=self.strides,
-                padding=self.padding
-            )
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                return tf.nn.avg_pool(
+                    X,
+                    ksize=self.ksize,
+                    strides=self.strides,
+                    padding=self.padding
+                )
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -615,13 +624,14 @@ class UpSamplingLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            t_shape = X.get_shape()
-            im_size = (t_shape[1] * self.size[0], t_shape[2] * self.size[1])
-            return tf.image.resize_nearest_neighbor(
-                X,
-                im_size
-            )
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                t_shape = X.get_shape()
+                im_size = (t_shape[1] * self.size[0], t_shape[2] * self.size[1])
+                return tf.image.resize_nearest_neighbor(
+                    X,
+                    im_size
+                )
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -673,8 +683,9 @@ class ActivationLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            return self.f(X, name=self._name)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                return self.f(X, name=self._name)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -718,8 +729,9 @@ class FlattenLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            return tf.contrib.layers.flatten(X)
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                return tf.contrib.layers.flatten(X)
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -775,11 +787,12 @@ class DropoutLayer(SimpleForwardLayer):
         return X
 
     def _training_forward(self, X):
-        with tf.name_scope(MakiRestorable.INFERENCE_MODE + self.get_name()):
-            return tf.nn.dropout(X, self._p_keep,
-                                 noise_shape=self.noise_shape,
-                                 seed=self.seed,
-            )
+        with tf.name_scope(MakiRestorable.TRAINING_MODE):
+            with tf.name_scope(self.get_name()):
+                return tf.nn.dropout(X, self._p_keep,
+                                     noise_shape=self.noise_shape,
+                                     seed=self.seed,
+                )
 
     @staticmethod
     def build(params: dict):
@@ -845,39 +858,40 @@ class ResizeLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            if self.interpolation == ResizeLayer.INTERPOLATION_BILINEAR:
-                return tf.image.resize_bilinear(
-                    X,
-                    self.new_shape,
-                    align_corners=self.align_corners,
-                    name=self._name,
-                )
-            elif self.interpolation == ResizeLayer.INTERPOLATION_NEAREST_NEIGHBOR:
-                return tf.image.resize_nearest_neighbor(
-                    X,
-                    self.new_shape,
-                    align_corners=self.align_corners,
-                    name=self._name,
-                )
-            elif self.interpolation == ResizeLayer.INTERPOLATION_AREA:
-                return tf.image.resize_area(
-                    X,
-                    self.new_shape,
-                    align_corners=self.align_corners,
-                    name=self._name,
-                )
-            elif self.interpolation == ResizeLayer.INTERPOLATION_BICUBIC:
-                return tf.image.resize_bicubic(
-                    X,
-                    self.new_shape,
-                    align_corners=self.align_corners,
-                    name=self._name,
-                )
-            else:
-                raise Exception(
-                    ResizeLayer._EXCEPTION_INTERPOLATION_IS_NOT_FOUND.format(self.interpolation)
-                )
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                if self.interpolation == ResizeLayer.INTERPOLATION_BILINEAR:
+                    return tf.image.resize_bilinear(
+                        X,
+                        self.new_shape,
+                        align_corners=self.align_corners,
+                        name=self._name,
+                    )
+                elif self.interpolation == ResizeLayer.INTERPOLATION_NEAREST_NEIGHBOR:
+                    return tf.image.resize_nearest_neighbor(
+                        X,
+                        self.new_shape,
+                        align_corners=self.align_corners,
+                        name=self._name,
+                    )
+                elif self.interpolation == ResizeLayer.INTERPOLATION_AREA:
+                    return tf.image.resize_area(
+                        X,
+                        self.new_shape,
+                        align_corners=self.align_corners,
+                        name=self._name,
+                    )
+                elif self.interpolation == ResizeLayer.INTERPOLATION_BICUBIC:
+                    return tf.image.resize_bicubic(
+                        X,
+                        self.new_shape,
+                        align_corners=self.align_corners,
+                        name=self._name,
+                    )
+                else:
+                    raise Exception(
+                        ResizeLayer._EXCEPTION_INTERPOLATION_IS_NOT_FOUND.format(self.interpolation)
+                    )
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)
@@ -925,10 +939,11 @@ class L2NormalizationLayer(SimpleForwardLayer):
         )
 
     def _forward(self, X, computation_mode=MakiRestorable.INFERENCE_MODE):
-        with tf.name_scope(computation_mode + self.get_name()):
-            return tf.math.l2_normalize(
-                x=X, epsilon=self._eps, axis=-1, name=self._name
-            )
+        with tf.name_scope(computation_mode):
+            with tf.name_scope(self.get_name()):
+                return tf.math.l2_normalize(
+                    x=X, epsilon=self._eps, axis=-1, name=self._name
+                )
 
     def _training_forward(self, X):
         return self._forward(X, computation_mode=MakiRestorable.TRAINING_MODE)

--- a/makiflow/models/regressor/training_modules/abs_loss.py
+++ b/makiflow/models/regressor/training_modules/abs_loss.py
@@ -36,7 +36,8 @@ class AbsTrainingModule(BasicTrainingModule):
         abs_loss = Loss.abs_loss(self._input_x, self._training_out, raw_tensor=True)
 
         if self._use_weight_mask_for_training:
-            abs_loss = tf.reduce_mean(abs_loss * self._weight_mask)
+            abs_loss = tf.reduce_sum(abs_loss * self._weight_mask)
+            abs_loss = abs_loss / tf.reduce_sum(self._weight_mask)
         else:
             abs_loss = tf.reduce_mean(abs_loss)
 

--- a/makiflow/models/regressor/training_modules/mse_loss.py
+++ b/makiflow/models/regressor/training_modules/mse_loss.py
@@ -36,7 +36,8 @@ class MseTrainingModule(BasicTrainingModule):
         mse_loss = Loss.mse_loss(self._input_x, self._training_out, raw_tensor=True)
 
         if self._use_weight_mask_for_training:
-            mse_loss = tf.reduce_mean(mse_loss * self._weight_mask)
+            mse_loss = tf.reduce_sum(mse_loss * self._weight_mask)
+            mse_loss = mse_loss / tf.reduce_sum(self._weight_mask)
         else:
             mse_loss = tf.reduce_mean(mse_loss)
 


### PR DESCRIPTION
Possibility to save model as pb (protobuf) file, also added names for operations in layers for TensorBoard usage.

Now layers displays in TensorBoard properly. In TensorBoard graph is splitted into Inference and Training graph , which is convenient to see. 